### PR TITLE
fix(compose): wait for backend healthcheck before starting frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - "3000:3000"
     depends_on:
       backend:
-        condition: service_started
+        condition: service_healthy
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
Change depends_on.backend.condition from service_started to service_healthy so the frontend waits for the backend's existing healthcheck to pass (start_period: 120s) before it comes online.

The SmolLM model takes roughly 90-120 seconds to download and load on first run. With service_started, the frontend container was starting as soon as the backend process existed, so chat requests sent during that window returned "503 Model not loaded yet". Using service_healthy defers the frontend until /health succeeds.