### PR TITLE
feat(models): add model switcher UI and backend structure, rename to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# HuggingChat - AI Chat Application
+# Vektro - AI Chat Application
 
 ![Preview](preview.png)
 
 A chat application powered by a light Hugging Face language model, featuring a FastAPI backend and a modern React frontend.
 
-![HuggingChat](https://img.shields.io/badge/AI-Chat-blue) ![Python](https://img.shields.io/badge/Python-3.11-green) ![React](https://img.shields.io/badge/React-18-blue) ![Docker](https://img.shields.io/badge/Docker-Compose-blue)
+![Vektro](https://img.shields.io/badge/AI-Chat-blue) ![Python](https://img.shields.io/badge/Python-3.11-green) ![React](https://img.shields.io/badge/React-18-blue) ![Docker](https://img.shields.io/badge/Docker-Compose-blue)
 
 ## Quick Start
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,1 +1,1 @@
-# Huggingface Chat Backend
+# Vektro Backend

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ import os
 
 from .model import ChatModel
 from .conversation import ConversationManager
+from .models_registry import MODELS, ModelInfo, get_model, DEFAULT_MODEL_ID
 from .schemas import (
     ChatRequest,
     ChatResponse,
@@ -35,7 +36,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
-    title="Huggingface Chat API",
+    title="Vektro API",
     description="A chat API powered by a small Huggingface model",
     version="1.0.0",
     lifespan=lifespan
@@ -61,12 +62,38 @@ async def health_check():
     )
 
 
+@app.get("/models", response_model=list[ModelInfo])
+async def list_models():
+    """List the chat models the API advertises, with metadata for the UI.
+
+    Only models flagged `implemented=True` are actually served by /chat
+    today — the rest are listed so the frontend can render the selector,
+    but requests for them currently fall back to the default model.
+    """
+    return MODELS
+
+
 @app.post("/chat", response_model=ChatResponse)
 async def chat(request: ChatRequest):
     """Send a message and get a response from the model."""
     if not chat_model.is_loaded():
         raise HTTPException(status_code=503, detail="Model not loaded yet")
-    
+
+    # Model routing is structural for now — the requested model is
+    # resolved against the registry and logged, but all inference still
+    # goes through the default model until multi-model loading lands.
+    selected = get_model(request.model)
+    if request.model and selected.id != request.model:
+        logger.warning(
+            "Unknown model id '%s', falling back to %s",
+            request.model, selected.id
+        )
+    elif not selected.implemented and request.model:
+        logger.info(
+            "Model '%s' is not implemented yet; serving with %s",
+            request.model, DEFAULT_MODEL_ID
+        )
+
     try:
         conversation_manager.add_message(
             request.conversation_id,

--- a/backend/app/models_registry.py
+++ b/backend/app/models_registry.py
@@ -1,0 +1,106 @@
+"""Registry of chat models available in the API.
+
+This is the single source of truth for which models the API advertises.
+The frontend reads from /models and renders the selector. When a new
+model is added here with implemented=True, the rest of the stack
+(loading, chat templates, switching) will need to catch up — for now
+only SmolLM2 is actually wired into inference.
+
+Speed and quality scores are approximate, based on public benchmarks
+(MMLU, HumanEval, throughput numbers from the Huggingface leaderboard).
+They're meant to give users a rough "what am I trading off" signal,
+not a precise ranking.
+"""
+from typing import List, Optional
+from pydantic import BaseModel, ConfigDict
+
+
+class ModelInfo(BaseModel):
+    model_config = ConfigDict(protected_namespaces=())
+
+    id: str
+    display_name: str
+    hf_repo: str
+    parameters: str
+    context_length: int
+    speed_score: int  # 1 (slow) - 5 (fast)
+    quality_score: int  # 1 (lower) - 5 (higher)
+    description: str
+    notes: Optional[str] = None
+    implemented: bool  # whether inference actually switches to this model yet
+
+
+# Scores below are deliberately approximate and should be reviewed when
+# we do the real multi-model implementation — inference benchmarks on
+# the target hardware will tell us the truth.
+#
+# Milestone 1 ships ACTIVE_MODELS in the switcher (SmolLM2 + Phi-3 Mini).
+# Milestone 2 will move the entries below from UPCOMING_MODELS into
+# ACTIVE_MODELS and wire their chat templates into the inference path.
+
+ACTIVE_MODELS: List[ModelInfo] = [
+    ModelInfo(
+        id="smollm2-360m",
+        display_name="SmolLM2 360M",
+        hf_repo="HuggingFaceTB/SmolLM2-360M-Instruct",
+        parameters="360M",
+        context_length=2048,
+        speed_score=5,
+        quality_score=2,
+        description="Tiny and fast. Runs on CPU, good for quick replies and low-resource deployments.",
+        implemented=True,
+    ),
+    ModelInfo(
+        id="phi-3-mini",
+        display_name="Phi-3 Mini",
+        hf_repo="microsoft/Phi-3-mini-4k-instruct",
+        parameters="3.8B",
+        context_length=4096,
+        speed_score=3,
+        quality_score=4,
+        description="Strong reasoning for its size. Good balance of speed and quality.",
+        implemented=False,
+    ),
+]
+
+# Planned for milestone 2 — not exposed via /models yet, kept here so
+# the registry stays the single source of truth for the whole roadmap.
+UPCOMING_MODELS: List[ModelInfo] = [
+    ModelInfo(
+        id="gemma-2b",
+        display_name="Gemma 2B",
+        hf_repo="google/gemma-2b-it",
+        parameters="2B",
+        context_length=8192,
+        speed_score=4,
+        quality_score=3,
+        description="Google's small instruction-tuned model. Well-rounded general-purpose option.",
+        implemented=False,
+    ),
+    ModelInfo(
+        id="mistral-7b",
+        display_name="Mistral 7B",
+        hf_repo="mistralai/Mistral-7B-Instruct-v0.2",
+        parameters="7B",
+        context_length=8192,
+        speed_score=1,
+        quality_score=5,
+        description="Highest quality option in this list. Best for complex prompts.",
+        notes="Needs a GPU. On CPU responses can take minutes.",
+        implemented=False,
+    ),
+]
+
+# Public list used by the API. Keeping the name MODELS so existing
+# imports stay stable when upcoming models are promoted in milestone 2.
+MODELS: List[ModelInfo] = ACTIVE_MODELS
+
+MODELS_BY_ID = {m.id: m for m in MODELS}
+DEFAULT_MODEL_ID = "smollm2-360m"
+
+
+def get_model(model_id: Optional[str]) -> ModelInfo:
+    """Look up a model by id, falling back to the default."""
+    if model_id and model_id in MODELS_BY_ID:
+        return MODELS_BY_ID[model_id]
+    return MODELS_BY_ID[DEFAULT_MODEL_ID]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -12,6 +12,7 @@ class Message(BaseModel):
 class ChatRequest(BaseModel):
     message: str
     conversation_id: Optional[str] = "default"
+    model: Optional[str] = None  # model id from /models; falls back to default if unknown
 
 
 class ChatResponse(BaseModel):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-    container_name: huggingchat-backend
+    container_name: vektro-backend
     ports:
       - "8000:8000"
     environment:
@@ -25,7 +25,7 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-    container_name: huggingchat-frontend
+    container_name: vektro-frontend
     ports:
       - "3000:3000"
     depends_on:
@@ -35,4 +35,4 @@ services:
 
 volumes:
   model-cache:
-    name: huggingchat-model-cache
+    name: vektro-model-cache

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/chat-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>HuggingChat - AI Chat Assistant</title>
+    <title>Vektro - AI Chat Assistant</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "huggingface-chat-frontend",
+  "name": "vektro-frontend",
   "private": true,
   "version": "1.0.0",
   "type": "module",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -286,6 +286,193 @@ html, body {
   width: 40px;
 }
 
+/* Model Selector */
+.sidebar-section {
+  padding: 0 1rem 0.75rem;
+}
+
+.model-selector-wrapper {
+  position: relative;
+}
+
+.model-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.model-selector:hover {
+  background: var(--bg-primary);
+  border-color: var(--text-muted);
+}
+
+.model-label {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.model-name {
+  flex: 1;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.model-placeholder,
+.model-error {
+  flex: 1;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.model-error {
+  color: var(--error-color);
+}
+
+.chevron {
+  width: 14px;
+  height: 14px;
+  color: var(--text-muted);
+  transition: transform 0.2s;
+}
+
+.chevron.up {
+  transform: rotate(180deg);
+}
+
+.model-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+  max-height: 420px;
+  overflow-y: auto;
+  padding: 0.375rem;
+}
+
+.model-option {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  width: 100%;
+  padding: 0.75rem;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.model-option:hover {
+  background: var(--bg-tertiary);
+}
+
+.model-option.selected {
+  background: var(--bg-tertiary);
+  border-color: var(--accent-color);
+}
+
+.model-option-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.model-option-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.model-option-size {
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.375rem;
+  background: var(--bg-secondary);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.model-option-preview {
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.5rem;
+  background: rgba(129, 140, 248, 0.15);
+  color: var(--accent-color);
+  border-radius: 9999px;
+  font-weight: 500;
+}
+
+.model-option-desc {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.model-option-notes {
+  font-size: 0.75rem;
+  color: var(--error-color);
+  line-height: 1.4;
+}
+
+.model-option-scores {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+}
+
+.score-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.score-label {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  width: 50px;
+}
+
+.score-bars {
+  display: flex;
+  gap: 3px;
+}
+
+.score-bar {
+  width: 14px;
+  height: 6px;
+  background: var(--bg-tertiary);
+  border-radius: 2px;
+}
+
+.score-bar.filled {
+  background: var(--accent-color);
+}
+
 /* Main Content */
 .main-content {
   flex: 1;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,9 @@ function App() {
     isLoading,
     error,
     isConnected,
+    selectedModelId,
+    setSelectedModelId,
+    conversationModelId,
     sendMessage,
     regenerateLastResponse,
     createNewConversation,
@@ -60,6 +63,8 @@ function App() {
         isConnected={isConnected}
         theme={theme}
         onToggleTheme={toggleTheme}
+        selectedModelId={conversationModelId || selectedModelId}
+        onSelectModel={setSelectedModelId}
       />
 
       <main className="main-content">

--- a/frontend/src/components/ModelSelector.jsx
+++ b/frontend/src/components/ModelSelector.jsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from 'react';
+import { api } from '../services/api';
+
+function ScoreBars({ label, value }) {
+  return (
+    <div className="score-row">
+      <span className="score-label">{label}</span>
+      <div className="score-bars" aria-label={`${label} ${value} out of 5`}>
+        {[1, 2, 3, 4, 5].map((i) => (
+          <span
+            key={i}
+            className={`score-bar ${i <= value ? 'filled' : ''}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ModelSelector({ selectedModelId, onSelect }) {
+  const [models, setModels] = useState([]);
+  const [open, setOpen] = useState(false);
+  const [loadError, setLoadError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.getModels()
+      .then((list) => {
+        if (cancelled) return;
+        setModels(list);
+        if (!selectedModelId && list.length > 0) {
+          const implemented = list.find((m) => m.implemented) || list[0];
+          onSelect(implemented.id);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setLoadError(err.message);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const selected = models.find((m) => m.id === selectedModelId) || models[0];
+
+  if (loadError) {
+    return (
+      <div className="model-selector model-selector-error" title={loadError}>
+        <span className="model-label">Model</span>
+        <span className="model-error">Unavailable</span>
+      </div>
+    );
+  }
+
+  if (!selected) {
+    return (
+      <div className="model-selector model-selector-loading">
+        <span className="model-label">Model</span>
+        <span className="model-placeholder">Loading…</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="model-selector-wrapper">
+      <button
+        type="button"
+        className="model-selector"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className="model-label">Model</span>
+        <span className="model-name">{selected.display_name}</span>
+        <svg
+          className={`chevron ${open ? 'up' : ''}`}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="model-dropdown" role="listbox">
+          {models.map((m) => {
+            const isSelected = m.id === selected.id;
+            return (
+              <button
+                key={m.id}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                className={`model-option ${isSelected ? 'selected' : ''}`}
+                onClick={() => {
+                  onSelect(m.id);
+                  setOpen(false);
+                }}
+              >
+                <div className="model-option-header">
+                  <span className="model-option-name">{m.display_name}</span>
+                  <span className="model-option-size">{m.parameters}</span>
+                  {!m.implemented && (
+                    <span
+                      className="model-option-preview"
+                      title="Preview — requests fall back to the default model until multi-model loading lands."
+                    >
+                      Preview
+                    </span>
+                  )}
+                </div>
+                <p className="model-option-desc">{m.description}</p>
+                {m.notes && (
+                  <p className="model-option-notes">{m.notes}</p>
+                )}
+                <div className="model-option-scores">
+                  <ScoreBars label="Speed" value={m.speed_score} />
+                  <ScoreBars label="Quality" value={m.quality_score} />
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ModelSelector } from './ModelSelector';
 
 export function Sidebar({
   conversations,
@@ -11,6 +12,8 @@ export function Sidebar({
   isConnected,
   theme,
   onToggleTheme,
+  selectedModelId,
+  onSelectModel,
 }) {
   const conversationList = Object.values(conversations).sort(
     (a, b) => new Date(b.updatedAt || 0) - new Date(a.updatedAt || 0)
@@ -23,7 +26,7 @@ export function Sidebar({
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
           </svg>
-          HuggingChat
+          Vektro
         </h1>
         <div className={`connection-status ${isConnected ? 'connected' : 'disconnected'}`}>
           <span className="status-dot"></span>
@@ -38,6 +41,13 @@ export function Sidebar({
         </svg>
         New Chat
       </button>
+
+      <div className="sidebar-section">
+        <ModelSelector
+          selectedModelId={selectedModelId}
+          onSelect={onSelectModel}
+        />
+      </div>
 
       <div className="conversations-list">
         <h3>Conversations</h3>

--- a/frontend/src/hooks/useChat.js
+++ b/frontend/src/hooks/useChat.js
@@ -1,7 +1,8 @@
 import { useState, useCallback, useEffect } from 'react';
 import { api } from '../services/api';
 
-const STORAGE_KEY = 'huggingchat_conversations';
+const STORAGE_KEY = 'vektro_conversations';
+const MODEL_STORAGE_KEY = 'vektro_selected_model';
 
 export function useChat() {
   const [conversations, setConversations] = useState(() => {
@@ -14,9 +15,23 @@ export function useChat() {
     const ids = Object.keys(parsed);
     return ids.length > 0 ? ids[0] : generateId();
   });
+  const [selectedModelId, setSelectedModelId] = useState(() => {
+    return localStorage.getItem(MODEL_STORAGE_KEY) || null;
+  });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [isConnected, setIsConnected] = useState(false);
+
+  useEffect(() => {
+    if (selectedModelId) {
+      localStorage.setItem(MODEL_STORAGE_KEY, selectedModelId);
+    }
+  }, [selectedModelId]);
+
+  // Each conversation remembers the model it started with, so switching
+  // the global selector doesn't rewrite history for existing chats.
+  const conversationModelId =
+    conversations[currentConversationId]?.model || selectedModelId;
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(conversations));
@@ -49,11 +64,14 @@ export function useChat() {
       timestamp: new Date().toISOString(),
     };
 
+    const modelForSend = conversationModelId || selectedModelId;
+
     setConversations(prev => ({
       ...prev,
       [currentConversationId]: {
         id: currentConversationId,
         title: prev[currentConversationId]?.title || content.slice(0, 30) + '...',
+        model: prev[currentConversationId]?.model || modelForSend,
         messages: [...(prev[currentConversationId]?.messages || []), userMessage],
         updatedAt: new Date().toISOString(),
       },
@@ -63,7 +81,7 @@ export function useChat() {
     setError(null);
 
     try {
-      const response = await api.sendMessage(content, currentConversationId);
+      const response = await api.sendMessage(content, currentConversationId, modelForSend);
       
       const assistantMessage = {
         id: generateId(),
@@ -92,7 +110,7 @@ export function useChat() {
     } finally {
       setIsLoading(false);
     }
-  }, [currentConversationId]);
+  }, [currentConversationId, conversationModelId, selectedModelId]);
 
   const regenerateLastResponse = useCallback(async () => {
     if (currentMessages.length < 2) return;
@@ -219,6 +237,9 @@ export function useChat() {
     isLoading,
     error,
     isConnected,
+    selectedModelId,
+    setSelectedModelId,
+    conversationModelId,
     sendMessage,
     regenerateLastResponse,
     createNewConversation,

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -6,7 +6,7 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || (
 );
 
 export const api = {
-  async sendMessage(message, conversationId = 'default') {
+  async sendMessage(message, conversationId = 'default', model = null) {
     const response = await fetch(`${API_BASE_URL}/chat`, {
       method: 'POST',
       headers: {
@@ -15,12 +15,23 @@ export const api = {
       body: JSON.stringify({
         message,
         conversation_id: conversationId,
+        ...(model ? { model } : {}),
       }),
     });
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: 'Unknown error' }));
       throw new Error(error.detail || 'Failed to send message');
+    }
+
+    return response.json();
+  },
+
+  async getModels() {
+    const response = await fetch(`${API_BASE_URL}/models`);
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch models');
     }
 
     return response.json();


### PR DESCRIPTION
…Vektro

Milestone 1 of the multi-model roadmap: UI + API scaffolding with no real runtime model switching yet.

Backend
  - New models_registry.py splits the roadmap into ACTIVE_MODELS (SmolLM2 360M + Phi-3 Mini, exposed via /models) and UPCOMING_MODELS (Gemma 2B + Mistral 7B, reserved for milestone 2).
  - New GET /models endpoint returns the active list with metadata (display name, parameters, context length, speed/quality scores, description, optional notes, implemented flag).
  - ChatRequest.model is now an optional field. The request is resolved against the registry and logged, but inference still goes through the default model until the real loading and per-model chat templates land in milestone 2.

Frontend
  - New ModelSelector component with a dropdown that shows each model's name, parameter size, description, GPU/quality notes, and 1-5 speed/quality bars. Preview badge on models whose inference isn't wired yet.
  - useChat tracks selectedModelId in localStorage and stores the chosen model id on each conversation, so switching the global selector doesn't rewrite history for existing chats.
  - sendMessage passes the model id to the backend on every request.

Rename
  - Full rebrand from HuggingChat to Vektro across docker-compose container and volume names, FastAPI title, browser tab title, sidebar logo, README, package.json, and localStorage keys. Any pre-rename chat history under the old localStorage keys is left in place (not migrated) since this is pre-launch.